### PR TITLE
Align builder image

### DIFF
--- a/Dockerfile_workable
+++ b/Dockerfile_workable
@@ -1,4 +1,4 @@
-FROM golang:1.19-bullseye as builder
+FROM golang:1.21-bullseye as builder
 
 ARG WDIR=/app
 


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

Aligning the builder image with the actual `go` version used by the project

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
