### PR TITLE
Fix condition of production image push

### DIFF
--- a/.github/workflows/common_image_tagging_workflow.yaml
+++ b/.github/workflows/common_image_tagging_workflow.yaml
@@ -31,7 +31,7 @@ jobs:
     
     steps:
       - name: validate inputs
-        if: inputs.push_to_prd && ( inputs.tag == '' || inputs.ref != 'main' )
+        if: inputs.push_to_prd && ( inputs.tag == '' || inputs.ref != 'workable_main' )
         shell: bash
         run: |
           echo "Images can be pushed to production GCR only if the build branch is 'main' and the image tag is provided manually"


### PR DESCRIPTION
## Problem Statement

Workaround to allow pushing images to `production` GCR if the build branch is `workable_main`

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
