### PR TITLE
Using workable_main for dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,26 +2,31 @@ version: 2
 updates:
 
   - package-ecosystem: "github-actions"
+    target-branch: "workable_main"
     directory: "/"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "docker"
+    target-branch: "workable_main"
     directory: "/"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: docker
+    target-branch: "workable_main"
     directory: /e2e
     schedule:
       interval: weekly
 
   - package-ecosystem: docker
+    target-branch: "workable_main"
     directory: /hack/api-docs
     schedule:
       interval: weekly
 
   - package-ecosystem: pip
+    target-branch: "workable_main"
     directory: /hack/api-docs
     schedule:
       interval: weekly


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

Set the correct branch for dependabot to monitor

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

Added `target-branch: "workable_main"` in all related `dependabot.yaml` entries that monitor for security patches.

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
